### PR TITLE
feat: support verbatim patch values

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,5 +11,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Set up Go
       uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
     - name: CI
       run: make ci

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ type K8sObjectOverlayPatch struct {
 	// All values are strings but are converted into appropriate type based on schema.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Value",order=2
 	Value string `json:"value,omitempty"`
+	// Verbatim value to add, delete or replace.
+	// Same as Value, however but the content is not interpreted as YAML, but treated as literal string instead.
+	// At least one of Value and Verbatim must be empty.
+	Verbatim string `json:"verbatim,omitempty"`
 }
 
 ```
@@ -132,8 +136,9 @@ func mapOverlayPatches(patches []*v1alpha1.K8sObjectOverlayPatch) []*types.K8sOb
 	out := make([]*types.K8sObjectOverlayPatch, len(patches))
 	for i, p := range patches {
 		out[i] = &types.K8sObjectOverlayPatch{
-			Path:  p.Path,
-			Value: p.Value,
+			Path:     p.Path,
+			Value:    p.Value,
+			Verbatim: p.Verbatim,
 		}
 	}
 	return out
@@ -164,5 +169,7 @@ spec:
     - path: data.foo
       value: bar
     - path: data.baz
-      value: qux
+      verbatim: |
+        qux
+        separate lines
 ```

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ type K8sObjectOverlayPatch struct {
 	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Value",order=2
 	Value string `json:"value,omitempty"`
 	// Verbatim value to add, delete or replace.
-	// Same as Value, however but the content is not interpreted as YAML, but treated as literal string instead.
+	// Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
 	// At least one of Value and Verbatim must be empty.
+	//+operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Verbatim",order=3
 	Verbatim string `json:"verbatim,omitempty"`
 }
 

--- a/pkg/types/overlay.go
+++ b/pkg/types/overlay.go
@@ -39,6 +39,10 @@ type K8sObjectOverlayPatch struct {
 	// For replace, path should reference an existing node.
 	// All values are strings but are converted into appropriate type based on schema.
 	Value string `json:"value,omitempty"`
+	// Verbatim value to add, delete or replace.
+	// Same as Value, however but the content is not interpreted as YAML, but treated as literal string instead.
+	// At least one of Value and Verbatim must be empty.
+	Verbatim string `json:"verbatim,omitempty"`
 }
 
 type OverlayObject struct {

--- a/pkg/types/overlay.go
+++ b/pkg/types/overlay.go
@@ -40,7 +40,7 @@ type K8sObjectOverlayPatch struct {
 	// All values are strings but are converted into appropriate type based on schema.
 	Value string `json:"value,omitempty"`
 	// Verbatim value to add, delete or replace.
-	// Same as Value, however but the content is not interpreted as YAML, but treated as literal string instead.
+	// Same as Value, however the content is not interpreted as YAML, but treated as literal string instead.
 	// At least one of Value and Verbatim must be empty.
 	Verbatim string `json:"verbatim,omitempty"`
 }


### PR DESCRIPTION
The `YAMLToJSON` call in `UnmarshalWithJSONPB` destroys newlines.
Since it's expected that the patch value is YAML, I think it's best to introduce a new field for verbatim values, to save users from having to do elaborate quoting of arbitrary data to pass through two layers of YAML.