### PR TITLE
fix: disable dynamic treatment of verbatim strings as YAML

### DIFF
--- a/pkg/patch/patch_test.go
+++ b/pkg/patch/patch_test.go
@@ -539,6 +539,10 @@ data:
 
       log_timezone = 'Etc/UTC' # comment
       more = false
+  - path: data.yaml_looking_file
+    verbatim: |
+     foo: true
+     bar: baz
 `
 	want := `
 apiVersion: v1
@@ -556,6 +560,9 @@ data:
   hba.conf: |-
     # PostgreSQL Client Authentication Configuration File
     local   all             all                                     scram-sha-256
+  yaml_looking_file: |
+   foo: true
+   bar: baz
 `
 	rc := &KubernetesResourcesSpec{}
 	if err := yaml.Unmarshal([]byte(overlays), rc); err != nil {

--- a/pkg/tpath/tree_test.go
+++ b/pkg/tpath/tree_test.go
@@ -350,7 +350,7 @@ a: {}
 				return
 			}
 
-			err := WritePathContext(pc, tt.value, false)
+			err := WritePathContext(pc, tt.value, false, true)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -752,7 +752,7 @@ values:
 		if err != nil {
 			t.Fatalf("GetPathContext(%q): %v", override.path, err)
 		}
-		err = WritePathContext(pc, override.value, false)
+		err = WritePathContext(pc, override.value, false, true)
 		if err != nil {
 			t.Fatalf("WritePathContext(%q): %v", override.path, err)
 		}
@@ -828,7 +828,7 @@ values:
 				return
 			}
 
-			err := WritePathContext(pc, tt.value, false)
+			err := WritePathContext(pc, tt.value, false, true)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
It turns out there is [another surprise layer of YAML unmashalling](https://github.com/stackrox/k8s-overlay-patch/blob/b9894e9f51581d68ee4981de437e17c5af72b97c/pkg/tpath/tree.go#L340) in this code, which only pops up if the value does look like valid YAML. 🤦🏻 

The changed test case fails with the following diff (note the `foo: bar` crawling up to the parent level!). The associated code changes prevent this.

```diff
 apiVersion: v1
 data:
-  foo: true
   hba.conf: |-
     # PostgreSQL Client Authentication Configuration File
     local   all             all                                     scram-sha-256
   postgresql.conf: |
     hba_file = '/etc/stackrox.d/config/pg_hba.conf'
     foo = "bar"
 
     log_timezone = 'Etc/UTC' # comment
     more = false
+  yaml_looking_file: |-
+    foo: true
+    bar: baz
 kind: ConfigMap
 metadata:
   name: a-cm
   namespace: stackrox
```